### PR TITLE
Fix/shipping delivery info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `bol-retailer-api` will be documented in this file.
 
 ## [Unreleased]
 
+### Changes
+- Refactored getDeliveryInfo, to ignore other fields in orderItems except `orderItemId`
+
 ## [v8.1.1] - 2023-03-29
 
 ### Changes

--- a/src/Endpoints/Shipping.php
+++ b/src/Endpoints/Shipping.php
@@ -43,7 +43,9 @@ class Shipping extends BaseEndpoint
             'POST',
             'shipping-labels/delivery-options',
             json_encode([
-                'orderItems' => $order->orderItems->toArray()
+                'orderItems' => $order->orderItems->map(function ($item) {
+                    return ['orderItemId' => $item->orderItemId];
+                })->toArray()
             ])
         );
 

--- a/tests/Feature/Endpoints/RetailerApi/ShippingTest.php
+++ b/tests/Feature/Endpoints/RetailerApi/ShippingTest.php
@@ -20,7 +20,8 @@ class ShippingTest extends TestCase
         $order = new Order([
             'orderItems' => [
                 [
-                    'orderItemId' => 2095052647
+                    'orderItemId' => 2095052647,
+                    'cancellationRequest' => false,
                 ]
             ]
         ]);


### PR DESCRIPTION
## Changes
- Refactored getDeliveryInfo, to ignore other fields in orderItems except `orderItemId`
